### PR TITLE
fix: correct typo for "Noble"

### DIFF
--- a/config/locales/quran.en.yml
+++ b/config/locales/quran.en.yml
@@ -121,7 +121,7 @@ en:
     sunnah_description: The Hadith of Prophet Muhammad(PBUH)
     salah: Salah
     salah_description: Search prayer time for any location
-    audio: Nobel Quran in audio
+    audio: Noble Quran in audio
     audio_description: Learning & listening at the same time
   close: Close
   noble_quran: The Noble Quran


### PR DESCRIPTION
@naveed-ahmad Typo in "Nobel"