### PR TITLE
Prevent Chapter List Items From Breaking

### DIFF
--- a/app/javascript/stylesheets/chapters.scss
+++ b/app/javascript/stylesheets/chapters.scss
@@ -136,6 +136,7 @@
         border-radius: 6px;
         padding: 10px 30px;
         margin-bottom: 20px;
+        break-inside: avoid-column;
 
         &:before {
           position: absolute;


### PR DESCRIPTION
Address #82 by preventing breaks inside a single list (surah) item.  Tested locally on OSX 12 Chrome 81.

Before:

![Screen Shot 2020-04-13 at 12 20 38 PM](https://user-images.githubusercontent.com/3638363/79139475-61e87200-7d84-11ea-9ba1-f954355fdd51.png)
![Screen Shot 2020-04-13 at 12 27 50 PM](https://user-images.githubusercontent.com/3638363/79139555-85132180-7d84-11ea-9eee-a6d39f87097a.png)

After:

![Screen Shot 2020-04-13 at 12 21 25 PM](https://user-images.githubusercontent.com/3638363/79139629-a411b380-7d84-11ea-8fe3-359fb36bf75a.png)
![Screen Shot 2020-04-13 at 12 27 42 PM](https://user-images.githubusercontent.com/3638363/79139634-a83dd100-7d84-11ea-9fa9-64e703fd8832.png)

