### PR TITLE
Only Allow Clear On Multi-Select. Fixes #84

### DIFF
--- a/app/javascript/controllers/select2_controller.js
+++ b/app/javascript/controllers/select2_controller.js
@@ -22,10 +22,11 @@ export default class extends Controller {
     });
     let el = $(this.element);
 
-    let options = {allowClear: true};
+    let options = {};
 
     if (el.data("multiple")) {
       options["multiple"] = true;
+      options["allowClear"] = true;
     }
 
     if (el.data("tags")) {


### PR DESCRIPTION
Addresses #84 

Only apply 'clear selection' control (small 'x') to multi-select fields as it does not apply to multi-select fields with default values.

Tested locally on OSX 12 Firefox 75

![Screen Shot 2020-04-13 at 4 59 58 PM](https://user-images.githubusercontent.com/3638363/79161240-1eecc580-7da9-11ea-8d69-7e7891cf0c1b.png)
![Screen Shot 2020-04-13 at 4 59 53 PM](https://user-images.githubusercontent.com/3638363/79161241-1eecc580-7da9-11ea-8fbc-5eeb2c0e19af.png)
