### PR TITLE
Update next page ref when jumping verses

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -35,7 +35,7 @@ class ChaptersController < ApplicationController
   def load_verses
     start = params[:verse].to_i
     from = params[:from] || start
-    to = params[:to] || start + 10
+    to = params[:to].to_i + 1 || start + 10
 
     params[:range] = "#{from}-#{to}"
     @presenter = ChapterPresenter.new(self)

--- a/app/javascript/controllers/chapter_controller.js
+++ b/app/javascript/controllers/chapter_controller.js
@@ -45,6 +45,18 @@ export default class extends Controller {
     });
   }
 
+  updatePagination(dom) {
+    const lastVerse = $(dom.find(".verse").last()).data("verseNumber");
+
+    // Update next page ref if it exists.
+    const nextPage = $("#verses_pagination a[rel=next]");
+    if (nextPage.length > 0) {
+      let ref = nextPage.attr('href');
+      const updatedRef = ref.replace(/page=\d+/, `page=${Math.ceil(lastVerse / 10) + 1}`);
+      nextPage.attr('href', updatedRef);
+    }
+  }
+
   loadVerses(verse) {
     // If this ayah is already loaded, scroll to it
     if ($(`#verses .verse[data-verse-number=${verse}]`).length > 0) {
@@ -59,7 +71,7 @@ export default class extends Controller {
 
     if (verse > lastVerse) {
       from = lastVerse;
-      to = verse;
+      to = Math.ceil(verse / 10) * 10;
     } else {
       from = verse;
       to = firstVerse;
@@ -69,7 +81,8 @@ export default class extends Controller {
       `/${chapter}/load_verses?${$.param({ from, to, verse })}`
     )
       .then(response => response.text())
-      .then(verses => this.insertVerses(verses));
+      .then(verses => this.insertVerses(verses))
+      .then(dom => this.updatePagination(dom));
 
     return Promise.resolve(request);
   }
@@ -121,5 +134,7 @@ export default class extends Controller {
       let targetDom = $(`#verses .verse[data-verse-number=${nextVerse}]`);
       targetDom.before(newVerses);
     }
+
+    return Promise.resolve(dom);
   }
 }


### PR DESCRIPTION
Currently, when jumping to a verse in a surah, it won't update the ref to the next page. This means that if you jump from the first page to ayah 33 in a surah (next page would be 5 in this case), it won't update the next ref attribute to point to page 5. It will keep the page ref at 2. So, if you continue to scroll down and autoload the next page, it will load the ayahs from page 2.

To fix, whenever we use the jump to feature, we update the next page ref to point to next page according to the last verse retrieved.