### PR TITLE
Fixed the license badge in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,5 +241,5 @@ Please [open an issue](https://github.com/quran/quran.com-frontend/issues/new) w
 [issues-shield]: https://img.shields.io/github/issues/quran/quran.com-frontend-v2?style=for-the-badge
 [issues-url]: https://github.com/quran/quran.com-frontend-v2/issues
 [license-shield]: https://img.shields.io/github/license/quran/quran.com-frontend-v2?style=for-the-badge
-[license-url]: https://github.com/quran/quran.com-frontend-v2/blob/master/LICENSE.txt
+[license-url]: https://github.com/quran/quran.com-frontend-v2/blob/master/LICENSE
 [product-screenshot]: images/screenshot.png


### PR DESCRIPTION
In the README.md, there is a license badge badge, if you click on it, it will bring you to an invalid webpage, I committed a simple fix to change the URL to the correct license. It was pointing to LICENSE.txt in the repo rather than the correct LICENSE.