### PR TITLE
fixed copied text/file, which was showing all translations if no translation was selected

### DIFF
--- a/app/presenters/advance_copy_presenter.rb
+++ b/app/presenters/advance_copy_presenter.rb
@@ -92,9 +92,7 @@ class AdvanceCopyPresenter < QuranPresenter
   end
 
   def fetch_approved_translations
-    strong_memoize :approve_translations do
-      valid_translations(store_result: false)
-    end
+    params[:translations].split(',')
   end
 
   def copying_from_surah?

--- a/app/views/advance_copy/copy_text.html.erb
+++ b/app/views/advance_copy/copy_text.html.erb
@@ -7,6 +7,7 @@
 <%= verse.verse_key %>
 <%= verse.text_uthmani.strip if include_arabic %>
 
+<%if @presenter.fetch_approved_translations.any?%>
 <% verse.translations.each do |tr| %>
 <%= @presenter.format_translation_text(tr).html_safe %>
 — <%= tr.resource_name %>
@@ -17,5 +18,5 @@
 <% end %>
 <% end %>
 <% end %>
-
+<% end %>
 <% end %>


### PR DESCRIPTION
fixed copied text/file, which was showing all translations if no translation was selected

fetching translation ids from the params instead of session