### PR TITLE
Improved readability of popular searches

### DIFF
--- a/app/javascript/stylesheets/organism/_content-page.scss
+++ b/app/javascript/stylesheets/organism/_content-page.scss
@@ -172,7 +172,7 @@
   overflow-x: scroll;
   // width: auto;
   flex: 1;
-  height: 40px;
+  height: 60px;
   margin-top: 4px;
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
Currently, in the live version as you can see in the first image, half the words are cut off due to insufficient height of the parent div.

-1 image 1 (live):
![before (live version)](https://user-images.githubusercontent.com/76709894/117726679-9335aa80-b1ef-11eb-99c5-2fe69efa6a65.png)

In this image, you can see my proposed change:

-2 image 2:
![after](https://user-images.githubusercontent.com/76709894/117726748-b2343c80-b1ef-11eb-9830-321e17a7ea63.png)
