### PR TITLE
fixed broken icon. issue: #422

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,7 @@ module ApplicationHelper
       ['Islamic/ Fiqh / Fatwa related questions',
        'Quran.com is an online reading, listening and studying tool. The team behind Quran.com is made up of software engineers, designers, and product managers. Unfortunately, that is the limitation of our skill set we do not have scholars, imams or sheikhs as part of the team to assist with Islamic, Fiqh or Fatwa related questions. We try to refrain from answering any of those questions and advise you speak to your local imam at a mosque or to a sheikh.'],
       ['Is Tafsir available?',
-       "Yes, we do have some Tafsirs. Click on <span class='icon icon-menu'></span> icon shown beside each ayah, then click on tafisrs. App will show you list of available tafsirs. Click on the tafsir you want to read."],
+       "Yes, we do have some Tafsirs. Click on <span class='quran-icon icon-menu'></span> icon shown beside each ayah, then click on tafisrs. App will show you list of available tafsirs. Click on the tafsir you want to read."],
       ['Add another translations',
        "Open a new issue at <a href='https://github.com/quran/quran.com-frontend-v2/issues/new?title=Add missing translation' target='_blank'>Github</a> with all the detail, link to translation and we'll try our best to add this."],
       ['Adding more reciters',


### PR DESCRIPTION
The class `quran-icon` was half missing, only the word `icon` was given to the `span` element which on its own do nothing as far as I understood.
I fixed the broken icon by fixing the broken class name. However, I noticed that the icon isn't aligned vertically, now I tried fixing it locally by using `vertical-align: middle;` which worked but I wasn't quite sure how to go about it in the project as a whole, editing the `quran-icon` class would affect every single icon that has it, and after testing that, it had side effects on other icons that were perfectly fine so I will leave that to you.