### PR TITLE
Bismillah text fix

### DIFF
--- a/app/javascript/stylesheets/utility/_chapter.scss
+++ b/app/javascript/stylesheets/utility/_chapter.scss
@@ -3,7 +3,7 @@
 }
 
 #bismillah{
-  font-size: 2.4rem;
+  font-size: 2.3rem;
 }
 
 .bismillah{

--- a/app/javascript/stylesheets/utility/_chapter.scss
+++ b/app/javascript/stylesheets/utility/_chapter.scss
@@ -3,7 +3,7 @@
 }
 
 #bismillah{
-  font-size: 40px;
+  font-size: 2.4rem;
 }
 
 .bismillah{

--- a/app/javascript/stylesheets/utility/_chapter.scss
+++ b/app/javascript/stylesheets/utility/_chapter.scss
@@ -3,7 +3,7 @@
 }
 
 #bismillah{
-  font-size: 2.3rem;
+  font-size: 2.4rem;
 }
 
 .bismillah{


### PR DESCRIPTION
In response to issue #478, font was changed from 40px to 2.4rem and apparently, it has fixed the problems.

### Complete text on full window

![Screenshot from 2021-08-12 10-53-48](https://user-images.githubusercontent.com/62377713/129146560-6bc53f73-07f4-4fda-aa2d-9ebbd69c1887.png)

### Text is also visible on small window
<div align="center">

![Screenshot from 2021-08-12 10-54-08](https://user-images.githubusercontent.com/62377713/129146572-87c81874-396b-40c2-a7c6-dc3e31e9c6a5.png)

</div>
